### PR TITLE
Fix 2D touchend issue

### DIFF
--- a/src/input/element-input.js
+++ b/src/input/element-input.js
@@ -393,7 +393,9 @@ pc.extend(pc, function () {
                 }
             }
 
-            this._touchedElements = newTouchedElements;
+            for (var touch in newTouchedElements) { 
+                this._touchedElements[touch] = newTouchedElements[touch]; 
+            }
         },
 
         _handleTouchEnd: function (event) {


### PR DESCRIPTION
This PR fixes annoying issue with 2D elements events.
Reproduce: 
1. Tap on element and keep holding it
2. Tap somewhere else
3. Release element. `Touchend` event doesn't fire then.

It appears because in _handleTouchStart we overwrite _touchedElements, which contains also a previously tapped event.
So instead of replacing, we merge it and then it works in appropriate way.

There is also a more clear solution with Object.assign, but I'm not sure about that, since it's on ES6.

Test project: https://playcanvas.com/project/557165/overview/touch-issue

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
